### PR TITLE
Remove forced group usage

### DIFF
--- a/BitlyApiV4/Bitly.cs
+++ b/BitlyApiV4/Bitly.cs
@@ -91,36 +91,21 @@ namespace BitlyAPI
 
         public async Task<BitlyLink> PostShorten(string longUrl, string groupGuid = null, string domain = null)
         {
-            if (groupGuid == null)
-            {
-                var groups = await GetGroups();
-                var groupsArray = groups as BitlyGroup[] ?? groups.ToArray();
-                if (!groupsArray.Any())
-                {
-                    throw new Exception("Unable to find groups for user");
-                }
+            var parameters = new Dictionary<string, string> {{"long_url", longUrl}};
 
-                var group = groupsArray.First();
-                groupGuid = group.Guid;
-                if (domain == null && group.Bsds.Any())
-                {
-                    domain = group.Bsds.First();
-                }
+            if (groupGuid != null)
+            {
+                parameters.Add("group_guid", groupGuid);
             }
 
-            var parameters = new Dictionary<string, string> {{"group_guid", groupGuid}, {"long_url", longUrl}};
             if (domain != null)
             {
                 parameters.Add("domain", domain);
             }
             
-            
             var response = await GetResponse<BitlyLink>("shorten", parameters,HttpMethod.Post);
             return response;
         }
-
-        
-
 
         public async Task<BitlyBitlinksResponse> GetBitlinksByGroup(
             string groupGuid = null, 


### PR DESCRIPTION
Currently the code forces you to use the first group returned from the groups query if you do not specify one but Bitly allows you to set a "Default API Group" and sets it by default if you only have one group.

The Bitly API will use this default if you do not send a group in the request which seems like a more sensible approach then forcing it to use a random group. 